### PR TITLE
Drop the lib prefix of module name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,13 @@ Installation instructions::
     $ cargo build
 
     # Copy the module to your FreeSWITCH modules directory:
-    $ sudo cp target/debug/libmod_prometheus.so `fs_cli -x 'global_getvar mod_dir'`
+    $ sudo cp target/debug/libmod_prometheus.so `fs_cli -x 'global_getvar mod_dir'`/mod_prometheus.so
 
     # Load the module:
-    $ fs_cli -x 'load libmod_prometheus'
+    $ fs_cli -x 'load mod_prometheus'
 
     # Make sure it's loaded and listening to TCP port 9282
-    $ fs_cli -x 'module_exists libmod_prometheus'
+    $ fs_cli -x 'module_exists mod_prometheus'
     true
 
     $ netstat -nl | grep 9282
@@ -39,7 +39,7 @@ Installation instructions::
     # For auto-load the module add this line at the end of your modules.conf 
     $ sudo vi /etc/freeswitch/autoload_configs/modules.conf.xml
 
-        <load module="libmod_prometheus"/>
+        <load module="mod_prometheus"/>
     
 Now you can access your host at port 9282 to check your metrics::
 

--- a/mod_prometheus.rs
+++ b/mod_prometheus.rs
@@ -439,4 +439,4 @@ static MOD_PROMETHEUS_DEF: ModDefinition = ModDefinition {
     shutdown: Some(prometheus_unload)
 };
 
-freeswitch_export_mod!(libmod_prometheus_module_interface, MOD_PROMETHEUS_DEF);
+freeswitch_export_mod!(mod_prometheus_module_interface, MOD_PROMETHEUS_DEF);


### PR DESCRIPTION
Follow the naming convention of FreeSWITCH modules.

Fixes #14.